### PR TITLE
bug-shachar-archive-job

### DIFF
--- a/src/store/modules/jobStore.js
+++ b/src/store/modules/jobStore.js
@@ -501,6 +501,7 @@ export const job = {
       // { dispatch }
       commit('setIsFetching', true)
       try {
+        if (!jobId || !applicantId) return
         const job = await jobService.getJobWithApplicant(jobId, applicantId)
         commit('setJob', {job: job})
         // dispatch(
@@ -512,7 +513,12 @@ export const job = {
         // )
       } catch (err) {
         loggerService.error('[JobStore] [loadJobWithApplicant] Failed to add job', err)
-        commit('app/setAlertData', {alertData: msgService.failArchive('job')}, {root: true})
+        // In the great tapestry of human communication, context is king.
+        // Words, like chameleons, adapt shift, and morph their meanings based on their surroundings.
+        // Yet, even in this fluid world of language, some phrases bear a widely accepted significance.
+        // So, when the phrase "Failed to add job" apears in the log, followed by an alert branded with 'failArchive',
+        // one can't help but feel a sudden urge to launch a dictionary as a gentle reminder of the beauty of linguistic accuracy.
+        // commit('app/setAlertData', {alertData: msgService.failArchive('job')}, {root: true})
       } finally {
         commit('setIsFetching', false)
       }

--- a/src/views/backoffice/applicant/ApplicantDetails.vue
+++ b/src/views/backoffice/applicant/ApplicantDetails.vue
@@ -238,7 +238,7 @@ export default {
       // #HANDLE CANCEL
       const key = 'job/getApplicantVideos'
       const cancelToken = await this.$store.dispatch('app/handleCancelRequest', key)
-
+      if (!this.job?._id || !applicantId) return
       const data = await jobService.getApplicantVideos(applicantId, this.job._id, cancelToken)
       if (!data) return
       const {answerMap} = data


### PR DESCRIPTION
this is related to the watchers triggering when leaving routes, so I added some simple guards to prevent the functions from running if information is missing.

Both of the errors in this PR could have been and should have been prevented by typescript when initially writing the functions.

See the comment in the jobStore to see why it was saying it couldn't archive the job.