### PR TITLE
added flush to applicantOverview watcher

### DIFF
--- a/src/views/backoffice/applicant/ApplicantOverview.vue
+++ b/src/views/backoffice/applicant/ApplicantOverview.vue
@@ -150,7 +150,7 @@ export default {
       clearSelectedItems()
       // this.setFilterFromRoute()
       loadApplicants()
-    })
+    },{flush:'post'})
     async function loadApplicants() {
       const {jobId} = route.params
       if (jobId) onSetFilterByKey('jobId', jobId)


### PR DESCRIPTION
Query params remain when navigating to applicant details,
in applicantOverview cmp, a watcher on the route add filter key to the params, added flush:post to the watcher so it would not activate when changing params to another page.