### PR TITLE
change saveWork to else only if  its not the  first change on the job

### DIFF
--- a/src/views/backoffice/JobEdit.vue
+++ b/src/views/backoffice/JobEdit.vue
@@ -219,7 +219,7 @@ export default {
       })
       if (this.jobEditErrors.length) return
       if (this.isFirstChange) this.$store.commit('job/setIsFirstChange', false)
-      await this.saveJob()
+      else this.saveJob()
     },
     // v model on components
 


### PR DESCRIPTION
when you created a job it would duplicate it on the first save, in the code it would check if its the first change but would not restrict the save if it is, added else condition to saveJob function